### PR TITLE
ui: changing init position to orient towards start node/first node

### DIFF
--- a/src/visualize-utils/Graph.js
+++ b/src/visualize-utils/Graph.js
@@ -44,7 +44,7 @@ export default class Graph {
 
     // initialising positions of nodes in circular format, the most optimal starting position for this algorithm
     initPositions(i, numNode) {
-        const angle = i * (2 * Math.PI) / numNode;
+        const angle = Math.PI - i * (2 * Math.PI) / numNode;
         const radius = this.radius;
         const x = radius * Math.cos(angle);
         const y = radius * Math.sin(angle);


### PR DESCRIPTION
the visualisation algorithm was starting from the first quadrant, changed that to third quadrant so that the first node ie starting node can be positioned as desired by general designs of automata